### PR TITLE
fix: make sure `default` package.json export is last

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
 	],
 	"exports": {
 		".": {
-			"default": "./dist/aruco-marker.modern.js",
-			"types": "./dist/aruco-marker.d.ts"
+			"types": "./dist/aruco-marker.d.ts",
+			"default": "./dist/aruco-marker.modern.js"
 		},
 		"./element": {
-			"default": "./dist/element.modern.js",
-			"types": "./dist/element.d.ts"
+			"types": "./dist/element.d.ts",
+			"default": "./dist/element.modern.js"
 		}
 	},
 	"main": "./dist/aruco-marker.cjs",


### PR DESCRIPTION
Importing this package in Next 14.1 results in an error:
```
Module not found: Default condition should be last one
  1 | import { Document, PDFViewer, Page, Text, View } from '@react-pdf/renderer';
> 2 | import { arucoToSVGString } from 'aruco-marker';
  3 |
  4 | import { IdentifiableInformationInput } from './identifiable-information-input.component';
  5 | import { SingleWordsInput } from './single-words-input.component';
```

Simply reordering the exports fixes it.